### PR TITLE
Add pagecolor support

### DIFF
--- a/unpacked/extensions/TeX/mediawiki-texvc.js
+++ b/unpacked/extensions/TeX/mediawiki-texvc.js
@@ -52,6 +52,7 @@ MathJax.Hub.Register.StartupHook("TeX Jax Ready", function () {
 			O: ["Macro", "\\emptyset"],
 			Omicron: ["Macro", "\\mathrm{O}"],
 			or: ["Macro", "\\lor"],
+			pagecolor: ['Macro','',1],  // ignore \pagecolor{}
 			part: ["Macro", "\\partial"],
 			plusmn: ["Macro", "\\pm"],
 			Q: ["Macro", "\\mathbb{Q}"],


### PR DESCRIPTION
Ignore pagecolor support as done for clientside MathJax in
https://gerrit.wikimedia.org/r/#/c/61256/1/modules/MathJax/extensions/TeX/texvc.js

Bug: T107578
